### PR TITLE
Update scripts to use 'dirname $0' on all files.

### DIFF
--- a/src/operations/checkout
+++ b/src/operations/checkout
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source ~/.oh-my-zsh/custom/plugins/zsh-git-fzf/src/operations/branch
+source "$(dirname "$0")/src/operations/branch"
 
 _checkout() {
     local branch=$(_branch)

--- a/src/operations/worktree
+++ b/src/operations/worktree
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-source ~/.oh-my-zsh/custom/plugins/zsh-git-fzf/src/helpers
-source ~/.oh-my-zsh/custom/plugins/zsh-git-fzf/src/completions
+source "$(dirname "$0")/src/helpers"
+source "$(dirname "$0")/src/completions"
 
 local FZF_OPTIONS="--no-preview"
 

--- a/zsh-git-fzf.plugin.zsh
+++ b/zsh-git-fzf.plugin.zsh
@@ -8,6 +8,7 @@ source "$(dirname "$0")/src/operations/diff"
 source "$(dirname "$0")/src/operations/log"
 source "$(dirname "$0")/src/operations/stash"
 source "$(dirname "$0")/src/operations/reflog"
+source "$(dirname "$0")/src/helpers"
 
 _help() {
     local PREFIX="git-fzf"


### PR DESCRIPTION
This prevents issues when running the plugin outside of '.oh-my-zsh', such as with 'zplug'.

Also included the 'helpers' function in 'zsh-git-fzf.plugin.zsh' so that 'colorful_echo' works.